### PR TITLE
Fully qualify libs in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["resources" "src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        http-kit {:mvn/version "2.3.0"}
+        http-kit/http-kit {:mvn/version "2.3.0"}
         metosin/jsonista {:mvn/version "0.2.5"}
-        hiccup {:mvn/version "2.0.0-alpha2"}
+        hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
         ring/ring-core {:mvn/version "1.8.0"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {org.clojure/test.check {:mvn/version "0.10.0"}}}


### PR DESCRIPTION
Fully qualify libs in deps.edn to prevent warning with recent versions of clojure (from a tool.deps.alpha changelog: `Deprecated use of unqualified lib names in deps.edn - will continue to work but will generate warnings`) 